### PR TITLE
Add i18n selector component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@emoji-mart/react": "^1.1.0",
         "@emotion/react": "^11.10.0",
         "@emotion/styled": "^11.10.0",
+        "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.0",
         "@octokit/core": "^4.2.0",
+        "all-iso-language-codes": "^1.0.11",
         "emoji-datasource": "^14.0.0",
         "emoji-mart": "^5.5.1",
         "emojilib": "^3.0.7",
@@ -25,7 +27,6 @@
         "react-dom": "^18.2.0",
         "react-github-btn": "^1.3.0",
         "react-i18next": "^12.1.4",
-        "unicode-emoji-json": "^0.4.0",
         "web-vitals": "^3.1.0"
       },
       "devDependencies": {
@@ -4036,6 +4037,31 @@
         "url": "https://opencollective.com/mui"
       }
     },
+    "node_modules/@mui/icons-material": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.0.tgz",
+      "integrity": "sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "5.11.7",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.11.7.tgz",
@@ -6389,6 +6415,11 @@
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
+    },
+    "node_modules/all-iso-language-codes": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/all-iso-language-codes/-/all-iso-language-codes-1.0.11.tgz",
+      "integrity": "sha512-Fp1e8Cj+jwCoLlDjeJ4iyK4vbHw8+axmZYDjnD0u4k+9SASwMz7RKBvYNbAyA6pVQPcQXdaM1DarPIEeiVlOCA=="
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -20691,11 +20722,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unicode-emoji-json": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.4.0.tgz",
-      "integrity": "sha512-lVNOwh2AnmbwqtSrEVjAWKQoVzWgyWmXVqPuPkPfKb0tnA0+uYN/4ILCTdy9IRj/+3drAVhmjwjNJQr2dhCwnA=="
-    },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
@@ -24785,6 +24811,14 @@
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.7.tgz",
       "integrity": "sha512-lZgX7XQTk0zVcpwEa80r+T4y09dosnUxWvFPSikU/2Hh5wnyNOek8WfJwGCNsaRiXJHMi5eHY+z8oku4u5lgNw=="
     },
+    "@mui/icons-material": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.0.tgz",
+      "integrity": "sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==",
+      "requires": {
+        "@babel/runtime": "^7.20.6"
+      }
+    },
     "@mui/material": {
       "version": "5.11.7",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.11.7.tgz",
@@ -26538,6 +26572,11 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "requires": {}
+    },
+    "all-iso-language-codes": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/all-iso-language-codes/-/all-iso-language-codes-1.0.11.tgz",
+      "integrity": "sha512-Fp1e8Cj+jwCoLlDjeJ4iyK4vbHw8+axmZYDjnD0u4k+9SASwMz7RKBvYNbAyA6pVQPcQXdaM1DarPIEeiVlOCA=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -37115,11 +37154,6 @@
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
       "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
       "dev": true
-    },
-    "unicode-emoji-json": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.4.0.tgz",
-      "integrity": "sha512-lVNOwh2AnmbwqtSrEVjAWKQoVzWgyWmXVqPuPkPfKb0tnA0+uYN/4ILCTdy9IRj/+3drAVhmjwjNJQr2dhCwnA=="
     },
     "unicode-match-property-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "octokit": "^2.0.7",
     "react-dom": "^18.2.0",
     "react-github-btn": "^1.3.0",
-    "react-i18next": "^12.1.4",    "unicode-emoji-json": "^0.4.0",
+    "react-i18next": "^12.1.4",
+    "unicode-emoji-json": "^0.4.0",
     "web-vitals": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "@emoji-mart/react": "^1.1.0",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
+    "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",
     "@octokit/core": "^4.2.0",
+    "all-iso-language-codes": "^1.0.11",
     "emoji-datasource": "^14.0.0",
     "emoji-mart": "^5.5.1",
     "emojilib": "^3.0.7",
@@ -49,8 +51,7 @@
     "octokit": "^2.0.7",
     "react-dom": "^18.2.0",
     "react-github-btn": "^1.3.0",
-    "react-i18next": "^12.1.4",
-    "unicode-emoji-json": "^0.4.0",
+    "react-i18next": "^12.1.4",    "unicode-emoji-json": "^0.4.0",
     "web-vitals": "^3.1.0"
   },
   "devDependencies": {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import GitHubButton from "react-github-btn";
 import { ThemeContext } from "../../store";
 import { ThemeSwitch } from "../ThemeSwitch";
 import { useTranslation } from "react-i18next";
+import { LocaleSelector } from "../LocaleSelector";
 
 /** Header component. */
 export const Header = () => {
@@ -99,6 +100,7 @@ export const Header = () => {
         <Grid container direction="column" alignItems="center">
           <Grid item>
             <ThemeSwitch checked={mode !== "dark"} onClick={toggleMode} />
+            <LocaleSelector />
           </Grid>
           <Grid item>
             <Typography variant="caption" align="center" pl={1} pr={1}>

--- a/src/components/LocaleSelector/LocaleSelector.tsx
+++ b/src/components/LocaleSelector/LocaleSelector.tsx
@@ -1,3 +1,7 @@
+/**
+ * @file LocaleSelector component.
+ */
+
 import { useCallback, useMemo, useState } from "react";
 import {
   Button,

--- a/src/components/LocaleSelector/LocaleSelector.tsx
+++ b/src/components/LocaleSelector/LocaleSelector.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  Button,
+  Popover,
+  Paper,
+  Grid,
+  styled,
+} from "@mui/material";
+import TranslateIcon from "@mui/icons-material/Translate";
+import { useTranslation } from "react-i18next";
+import { getEmojiFlag } from "../../utils/getEmojiFlag";
+import { getName, getIsoCodesFromNativeName } from "all-iso-language-codes";
+
+export const LocaleSelector = () => {
+  const { i18n } = useTranslation();
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  /**
+   * The current URL pathname
+   */
+  const url = new URLSearchParams(window.location.search);
+
+  /**
+   * A list of supported Alpha2 shortcodes e.g "en" "nl"
+   */
+  const supportedLocales = useMemo(
+    () =>
+      Array.from(new Set(i18n.options.supportedLngs || [])).filter(
+        (l) => l !== "cimode"
+      ),
+    []
+  );
+
+  const open = Boolean(anchorEl);
+  const id = open ? "locale-selector" : undefined;
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  /**
+   * Switches the app locale by appending a query parameter to the URL, e.g. ?lng=en
+   * TODO: Changing the locale appears to break for certain locales. https://github.com/missive/emoji-mart/issues/794. UX can be preserved by reloading rather than just re-rendering.
+   */
+  const setLocale = useCallback((lng: string) => {
+    url.set("lng", lng);
+    i18n.changeLanguage(lng);
+
+    // Update without reload
+    // window.history.pushState({}, "", url.toString());
+    
+    // Update with reload
+    window.location.search = url.toString();
+  }, []);
+
+  return (
+    <>
+      <Button aria-describedby={id} variant="text" onClick={handleClick}>
+        <TranslateIcon />
+      </Button>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Paper>
+          <Grid container spacing={2} maxWidth={600} p={2}>
+            {supportedLocales.map((lng) => (
+              <Grid item xs={6} sm={4} md={3} key={lng}>
+                <LocaleOpt onClick={() => setLocale(lng)}>
+                  <span>{getEmojiFlag(lng)}</span>
+                  <span>{getName(lng, i18n.resolvedLanguage)}</span>
+                </LocaleOpt>
+              </Grid>
+            ))}
+          </Grid>
+        </Paper>
+      </Popover>
+    </>
+  );
+};
+
+export default LocaleSelector;
+
+const LocaleOpt = styled(Button)(({ theme }) => ({
+  textTransform: "none",
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  alignItems: "center",
+  flexDirection: "row",
+  gap: 10,
+  display: "flex",
+  color: theme.palette.text.secondary,
+  fontWeight: "bold",
+}));

--- a/src/components/LocaleSelector/index.ts
+++ b/src/components/LocaleSelector/index.ts
@@ -1,0 +1,1 @@
+export { LocaleSelector } from "./LocaleSelector";

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -21,6 +21,32 @@ i18n
   .init({
     debug: true,
     fallbackLng: "en",
+    supportedLngs: [
+      "en",
+      "ar",
+      "be",
+      "cs",
+      "de",
+      "en",
+      "es",
+      "fa",
+      "fr",
+      "hi",
+      "it",
+      "ja",
+      "ko",
+      "nl",
+      "pl",
+      "pt",
+      "ru",
+      "sa",
+      "ru",
+      "sa",
+      "tr",
+      "uk",
+      "vi",
+      "zh",
+    ],
   });
 
 export default i18n;

--- a/src/utils/getEmojiFlag.ts
+++ b/src/utils/getEmojiFlag.ts
@@ -1,0 +1,46 @@
+/**
+ * @file Contains the function `getEmojiFlag` that converts country codes to emoji flags
+ */
+
+// https://gist.github.com/RienNeVaPlus/307d19b1c33fbb2545eca5c83d3bad83
+
+/**
+ * 🏁 Returns an unicode-emoji-flag-icon for a two digit country code or a locale (eg. en-US)
+ * - Supports 239 countries
+ *
+ * @param {String} countryCode - the country code to display a flag for (eg. US)
+ * @param {String} [fallback=🏳] - fallback icon when no matching flag has been found
+ * @param {Object} [countryFlagData] - an object of country code : flag
+ */
+export function getEmojiFlag(countryCode: string, fallback: string = '🏳', countryFlagData: {[key: string]: string} = {
+	AD: '🇦🇩', AE: '🇦🇪', AF: '🇦🇫', AG: '🇦🇬', AI: '🇦🇮', AL: '🇦🇱', AM: '🇦🇲', AO: '🇦🇴', AQ: '🇦🇶', AR: '🇦🇪',
+	AS: '🇦🇸', AT: '🇦🇹', AU: '🇦🇺', AW: '🇦🇼', AX: '🇦🇽', AZ: '🇦🇿', BA: '🇧🇦', BB: '🇧🇧', BD: '🇧🇩', 
+	BF: '🇧🇫', BG: '🇧🇬', BH: '🇧🇭', BI: '🇧🇮', BJ: '🇧🇯', BL: '🇧🇱', BM: '🇧🇲', BN: '🇧🇳', BO: '🇧🇴', BQ: '🇧🇶',
+	BR: '🇧🇷', BS: '🇧🇸', BT: '🇧🇹', BV: '🇧🇻', BW: '🇧🇼', BY: '🇧🇾', BZ: '🇧🇿', CA: '🇨🇦', CC: '🇨🇨', CD: '🇨🇩',
+	CF: '🇨🇫', CG: '🇨🇬', CH: '🇨🇭', CI: '🇨🇮', CK: '🇨🇰', CL: '🇨🇱', CM: '🇨🇲', CN: '🇨🇳', CO: '🇨🇴', CR: '🇨🇷',
+	CU: '🇨🇺', CV: '🇨🇻', CW: '🇨🇼', CX: '🇨🇽', CY: '🇨🇾', CZ: '🇨🇿', DE: '🇩🇪', DJ: '🇩🇯', DK: '🇩🇰', DM: '🇩🇲',
+	DO: '🇩🇴', DZ: '🇩🇿', EC: '🇪🇨', EE: '🇪🇪', EG: '🇪🇬', EH: '🇪🇭', ER: '🇪🇷', ES: '🇪🇸', ET: '🇪🇹', FI: '🇫🇮',
+	FJ: '🇫🇯', FK: '🇫🇰', FM: '🇫🇲', FO: '🇫🇴', FR: '🇫🇷', GA: '🇬🇦', GB: '🇬🇧', GD: '🇬🇩', GE: '🇬🇪', GF: '🇬🇫',
+	GG: '🇬🇬', GH: '🇬🇭', GI: '🇬🇮', GL: '🇬🇱', GM: '🇬🇲', GN: '🇬🇳', GP: '🇬🇵', GQ: '🇬🇶', GR: '🇬🇷', GS: '🇬🇸',
+	GT: '🇬🇹', GU: '🇬🇺', GW: '🇬🇼', GY: '🇬🇾', HK: '🇭🇰', HM: '🇭🇲', HN: '🇭🇳', HR: '🇭🇷', HT: '🇭🇹', HU: '🇭🇺',
+	ID: '🇮🇩', IE: '🇮🇪', IL: '🇮🇱', IM: '🇮🇲', IN: '🇮🇳', IO: '🇮🇴', IQ: '🇮🇶', IR: '🇮🇷', IS: '🇮🇸', IT: '🇮🇹',
+	JE: '🇯🇪', JM: '🇯🇲', JO: '🇯🇴', JP: '🇯🇵', KE: '🇰🇪', KG: '🇰🇬', KH: '🇰🇭', KI: '🇰🇮', KM: '🇰🇲', KN: '🇰🇳',
+	KP: '🇰🇵', KR: '🇰🇷', KW: '🇰🇼', KY: '🇰🇾', KZ: '🇰🇿', LA: '🇱🇦', LB: '🇱🇧', LC: '🇱🇨', LI: '🇱🇮', LK: '🇱🇰',
+	LR: '🇱🇷', LS: '🇱🇸', LT: '🇱🇹', LU: '🇱🇺', LV: '🇱🇻', LY: '🇱🇾', MA: '🇲🇦', MC: '🇲🇨', MD: '🇲🇩', ME: '🇲🇪',
+	MF: '🇲🇫', MG: '🇲🇬', MH: '🇲🇭', MK: '🇲🇰', ML: '🇲🇱', MM: '🇲🇲', MN: '🇲🇳', MO: '🇲🇴', MP: '🇲🇵', MQ: '🇲🇶',
+	MR: '🇲🇷', MS: '🇲🇸', MT: '🇲🇹', MU: '🇲🇺', MV: '🇲🇻', MW: '🇲🇼', MX: '🇲🇽', MY: '🇲🇾', MZ: '🇲🇿', NA: '🇳🇦',
+	NC: '🇳🇨', NE: '🇳🇪', NF: '🇳🇫', NG: '🇳🇬', NI: '🇳🇮', NL: '🇳🇱', NO: '🇳🇴', NP: '🇳🇵', NR: '🇳🇷', NU: '🇳🇺',
+	NZ: '🇳🇿', OM: '🇴🇲', PA: '🇵🇦', PE: '🇵🇪', PF: '🇵🇫', PG: '🇵🇬', PH: '🇵🇭', PK: '🇵🇰', PL: '🇵🇱', PM: '🇵🇲',
+	PN: '🇵🇳', PR: '🇵🇷', PS: '🇵🇸', PT: '🇵🇹', PW: '🇵🇼', PY: '🇵🇾', QA: '🇶🇦', RE: '🇷🇪', RO: '🇷🇴', RS: '🇷🇸',
+	RU: '🇷🇺', RW: '🇷🇼', SB: '🇸🇧', SC: '🇸🇨', SD: '🇸🇩', SE: '🇸🇪', SG: '🇸🇬', SH: '🇸🇭', SI: '🇸🇮',
+	SJ: '🇸🇯', SK: '🇸🇰', SL: '🇸🇱', SM: '🇸🇲', SN: '🇸🇳', SO: '🇸🇴', SR: '🇸🇷', SS: '🇸🇸', ST: '🇸🇹', SV: '🇸🇻',
+	SX: '🇸🇽', SY: '🇸🇾', SZ: '🇸🇿', TC: '🇹🇨', TD: '🇹🇩', TF: '🇹🇫', TG: '🇹🇬', TH: '🇹🇭', TJ: '🇹🇯', TK: '🇹🇰',
+	TL: '🇹🇱', TM: '🇹🇲', TN: '🇹🇳', TO: '🇹🇴', TR: '🇹🇷', TT: '🇹🇹', TV: '🇹🇻', TW: '🇹🇼', TZ: '🇹🇿', UA: '🇺🇦',
+	UG: '🇺🇬', UM: '🇺🇲', US: '🇺🇸', UY: '🇺🇾', UZ: '🇺🇿', VA: '🇻🇦', VC: '🇻🇨', VE: '🇻🇪', VG: '🇻🇬', 
+	VN: '🇻🇳', VU: '🇻🇺', WF: '🇼🇫', WS: '🇼🇸', XK: '🇽🇰', YE: '🇾🇪', YT: '🇾🇹', ZA: '🇿🇦', ZM: '🇿🇲', 
+    /** Manually linking some flags to language shortcodes */
+    EN: '🇬🇧', CS: '🇨🇿', FA: '🇮🇷', HI: '🇮🇳', SA: '🇮🇳', JA: '🇯🇵', KO: '🇰🇷', UK: '🇺🇦', VI: '🇻🇳', ZH: '🇨🇳', BE: '🇧🇾'
+}){
+	const arr = countryCode.split('-');
+	return countryFlagData[(arr[1] || arr[0]).toUpperCase()] || fallback;
+}

--- a/src/utils/getEmojiFlag.ts
+++ b/src/utils/getEmojiFlag.ts
@@ -2,11 +2,12 @@
  * @file Contains the function `getEmojiFlag` that converts country codes to emoji flags
  */
 
-// https://gist.github.com/RienNeVaPlus/307d19b1c33fbb2545eca5c83d3bad83
 
 /**
  * 🏁 Returns an unicode-emoji-flag-icon for a two digit country code or a locale (eg. en-US)
  * - Supports 239 countries
+ * 
+ * https://gist.github.com/RienNeVaPlus/307d19b1c33fbb2545eca5c83d3bad83
  *
  * @param {String} countryCode - the country code to display a flag for (eg. US)
  * @param {String} [fallback=🏳] - fallback icon when no matching flag has been found


### PR DESCRIPTION
I've added a locale selector component, and tried to adhere to the code style. 

There appears to be an issue with changing the `<Picker />`'s locale with custom categories enabled. https://github.com/missive/emoji-mart/issues/794

To workaround that, the page reloads when changing locale rather than just re-rendering the component. 