### PR TITLE
ci: prevent label remove

### DIFF
--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: ''


### PR DESCRIPTION
This prevents the removal of labels that occurs due to a bug in 'actions/labeler' (see https://github.com/actions/labeler/issues/112).