### PR TITLE
feat: add copy type query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A simple Emoji picker that displays all the emojis that GitHub supports. It is a
 
 ## How to use
 
-Use the search field to search for a given emoji. You can click the emoji to get the shortcode on your clipboard or `shift` + click for the Unicode.
+Use the search field to search for a given emoji. You can click the emoji to get the shortcode on your clipboard or `shift` + click for the Unicode. You can invert the copy behaviour by setting the `copy_type` URL parameter to `unicode` or `shortcode`.
 
 ## Contributing
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,16 @@
+/**
+ * @file Utility functions.
+ */
+
+/**
+ * Convert unified to unicode emoji.
+ * @param unified - the unified string.
+ * @returns the unicode emoji.
+ */
+const unifiedToUnicodeEmoji = (unified: string) => {
+  return String.fromCodePoint(
+    ...unified.split("-").map((str: string) => parseInt(str, 16))
+  );
+};
+
+export { unifiedToUnicodeEmoji };


### PR DESCRIPTION
This commit gives users the ability to invert the copy behavoir by setting the
`copy_type` URL parameter to `unicode` or `shortcode`.
