### PR TITLE
ci: update node version

### DIFF
--- a/.github/workflows/update_emojis.yml
+++ b/.github/workflows/update_emojis.yml
@@ -2,6 +2,7 @@ name: Up to Date
 on:
   schedule:
     - cron: "0 0 */7 * *"
+  workflow_dispatch:
 
 jobs:
   update:
@@ -16,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/update_supported_locals.yml
+++ b/.github/workflows/update_supported_locals.yml
@@ -3,6 +3,7 @@ name: "Update supported locales"
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   updateSupportedLocales:
@@ -16,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This pull request updates the node version used in the actions to 18 to fix
the fetch command not being available inside the actions (see
https://github.com/rickstaa/github-emoji-picker/actions/runs/5627711205/job/15250664395).
