### PR TITLE
Fix Czech translation

### DIFF
--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -1,6 +1,6 @@
 {
-    "header.description": "Jednoduchý výběr emocí, který zobrazuje všechny podporované GitHuby.",
-    "header.themeSwitch.description": "Přepněte na preferovanou šablonu a jazyk.",
+    "header.description": "Jednoduchý výběr emoji, který zobrazuje všechny podporované emoji na GitHubu.",
+    "header.themeSwitch.description": "Přepněte na preferované téma a jazyk.",
     "footer.description": "Vyrobeno s",
     "localeSelector.translate": "Přeložit"
 }


### PR DESCRIPTION
This will fix czech translation. The original sentence said something like

> A simple emotion picker that displays all supported GitHubs

You pick emoji rather than emotion and "the picker shows all supported emojis on Github" rather than "all supported GitHubs"