### PR TITLE
chore: disable vercel telemetry

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import reportWebVitals from "./reportWebVitals";
-import { sendToVercelAnalytics } from "./vitals";
+// import reportWebVitals from "./reportWebVitals";
+// import { sendToVercelAnalytics } from "./vitals";
 
 import "./i18n";
 
@@ -18,6 +18,6 @@ root.render(
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-if (process.env.NODE_ENV === "production") {
-  reportWebVitals(sendToVercelAnalytics);
-}
+// if (process.env.NODE_ENV === "production") {
+//   reportWebVitals(sendToVercelAnalytics);
+// }


### PR DESCRIPTION
This pull request disables the Vercel telemetry since it is no longer needed now that the app has been functioning correctly for over a year.
